### PR TITLE
Using default 4h timeout for each task in rh-advisories pipeline

### DIFF
--- a/pipelines/managed/rh-advisories/rh-advisories.yaml
+++ b/pipelines/managed/rh-advisories/rh-advisories.yaml
@@ -59,6 +59,10 @@ spec:
     - name: taskGitRevision
       type: string
       description: The revision in the taskGitUrl repo to be used
+    - name: defaultTaskTimeout
+      type: string
+      description: Default timeout for a Task
+      default: "4h00m0s"
   workspaces:
     - name: release-workspace
   results:
@@ -67,6 +71,7 @@ spec:
       value: $(tasks.create-advisory.results.advisory_url)
   tasks:
     - name: verify-access-to-resources
+      timeout: $(params.defaultTaskTimeout)
       taskRef:
         resolver: "git"
         params:
@@ -90,6 +95,7 @@ spec:
         - name: requireInternalServices
           value: "true"
     - name: collect-data
+      timeout: $(params.defaultTaskTimeout)
       taskRef:
         resolver: "git"
         params:
@@ -118,6 +124,7 @@ spec:
       runAfter:
         - verify-access-to-resources
     - name: reduce-snapshot
+      timeout: $(params.defaultTaskTimeout)
       taskRef:
         resolver: "git"
         params:
@@ -144,6 +151,7 @@ spec:
       runAfter:
         - collect-data
     - name: extract-requester-from-release
+      timeout: $(params.defaultTaskTimeout)
       taskRef:
         resolver: "git"
         params:
@@ -171,6 +179,7 @@ spec:
       runAfter:
         - verify-access-to-resources
     - name: apply-mapping
+      timeout: $(params.defaultTaskTimeout)
       retries: 3
       taskRef:
         resolver: "git"
@@ -227,6 +236,7 @@ spec:
       runAfter:
         - apply-mapping
     - name: populate-release-notes-images
+      timeout: $(params.defaultTaskTimeout)
       params:
         - name: dataPath
           value: "$(tasks.collect-data.results.data)"
@@ -247,6 +257,7 @@ spec:
         - name: data
           workspace: release-workspace
     - name: embargo-check
+      timeout: $(params.defaultTaskTimeout)
       params:
         - name: dataPath
           value: "$(tasks.collect-data.results.data)"
@@ -267,6 +278,7 @@ spec:
       runAfter:
         - populate-release-notes-images
     - name: collect-cosign-params
+      timeout: $(params.defaultTaskTimeout)
       taskRef:
         resolver: "git"
         params:
@@ -285,6 +297,7 @@ spec:
       runAfter:
         - collect-data
     - name: rh-sign-image-cosign
+      timeout: $(params.defaultTaskTimeout)
       when:
         - input: $(tasks.collect-cosign-params.results.cosign-secret-name)
           operator: notin
@@ -313,6 +326,7 @@ spec:
         - push-snapshot
         - collect-cosign-params
     - name: push-snapshot
+      timeout: $(params.defaultTaskTimeout)
       retries: 5
       when:
         - input: "$(tasks.apply-mapping.results.mapped)"
@@ -340,6 +354,7 @@ spec:
       runAfter:
         - rh-sign-image
     - name: collect-pyxis-params
+      timeout: $(params.defaultTaskTimeout)
       taskRef:
         resolver: "git"
         params:
@@ -403,6 +418,7 @@ spec:
         - publish-pyxis-repository
         - extract-requester-from-release
     - name: create-pyxis-image
+      timeout: $(params.defaultTaskTimeout)
       retries: 5
       taskRef:
         resolver: "git"
@@ -430,6 +446,7 @@ spec:
       runAfter:
         - push-snapshot
     - name: publish-pyxis-repository
+      timeout: $(params.defaultTaskTimeout)
       retries: 5
       taskRef:
         resolver: "git"
@@ -458,6 +475,7 @@ spec:
         - collect-pyxis-params
         - apply-mapping
     - name: push-rpm-data-to-pyxis
+      timeout: $(params.defaultTaskTimeout)
       retries: 5
       taskRef:
         resolver: "git"
@@ -481,6 +499,7 @@ spec:
       runAfter:
         - create-pyxis-image
     - name: update-component-sbom
+      timeout: $(params.defaultTaskTimeout)
       when:
         - input: "$(tasks.collect-atlas-params.results.secretName)"
           operator: notin
@@ -508,6 +527,7 @@ spec:
         - push-rpm-data-to-pyxis
         - populate-release-notes-images
     - name: upload-component-sbom
+      timeout: $(params.defaultTaskTimeout)
       when:
         - input: "$(tasks.collect-atlas-params.results.secretName)"
           operator: notin
@@ -536,6 +556,7 @@ spec:
       runAfter:
         - update-component-sbom
     - name: run-file-updates
+      timeout: $(params.defaultTaskTimeout)
       params:
         - name: fileUpdatesPath
           value: $(tasks.collect-data.results.data)
@@ -563,6 +584,7 @@ spec:
         - name: data
           workspace: release-workspace
     - name: check-data-keys
+      timeout: $(params.defaultTaskTimeout)
       params:
         - name: dataPath
           value: "$(tasks.collect-data.results.data)"
@@ -589,6 +611,7 @@ spec:
       runAfter:
         - populate-release-notes-images
     - name: collect-atlas-params
+      timeout: $(params.defaultTaskTimeout)
       taskRef:
         resolver: "git"
         params:
@@ -607,6 +630,7 @@ spec:
       runAfter:
         - collect-data
     - name: create-product-sbom
+      timeout: $(params.defaultTaskTimeout)
       when:
         - input: "$(tasks.collect-atlas-params.results.secretName)"
           operator: notin
@@ -630,6 +654,7 @@ spec:
         - collect-atlas-params
         - populate-release-notes-images
     - name: upload-product-sbom
+      timeout: $(params.defaultTaskTimeout)
       when:
         - input: "$(tasks.collect-atlas-params.results.secretName)"
           operator: notin
@@ -658,6 +683,7 @@ spec:
       runAfter:
         - create-product-sbom
     - name: create-advisory
+      timeout: $(params.defaultTaskTimeout)
       retries: 5
       params:
         - name: releasePlanAdmissionPath
@@ -690,6 +716,7 @@ spec:
         - rh-sign-image
         - rh-sign-image-cosign
     - name: update-cr-status
+      timeout: $(params.defaultTaskTimeout)
       params:
         - name: resource
           value: $(params.release)
@@ -711,6 +738,7 @@ spec:
         - create-advisory
   finally:
     - name: cleanup
+      timeout: $(params.defaultTaskTimeout)
       taskRef:
         resolver: "git"
         params:


### PR DESCRIPTION
Increasing the default timeout to 4h for tasks in the rh-advisory pipeline

Slack: https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1737646395651019?thread_ts=1737101984.995239&cid=C04PZ7H0VA8